### PR TITLE
Add self-healing watcher daemon for Configuration Profile sync

### DIFF
--- a/DDMNotifier/Sources/LaunchDaemonManager/LaunchDaemonManager.swift
+++ b/DDMNotifier/Sources/LaunchDaemonManager/LaunchDaemonManager.swift
@@ -27,6 +27,10 @@ class LaunchDaemonManager {
         return "/Library/LaunchDaemons/\(preferenceDomain).plist"
     }
 
+    private var watcherDaemonPath: String {
+        return "/Library/LaunchDaemons/\(preferenceDomain).watcher.plist"
+    }
+
     private var binaryPath: String {
         return "/usr/local/bin/DDMmacOSUpdateReminder"
     }
@@ -191,5 +195,164 @@ class LaunchDaemonManager {
         try? FileManager.default.removeItem(atPath: daemonPath)
 
         Logger.shared.launchDaemon("Removed LaunchDaemon")
+    }
+
+    // MARK: - Watcher Daemon
+
+    func createOrUpdateWatcherDaemon() throws {
+        Logger.shared.launchDaemon("Creating/updating watcher LaunchDaemon")
+
+        // Verify binary exists
+        guard FileManager.default.fileExists(atPath: binaryPath) else {
+            Logger.shared.error("Binary not found at \(binaryPath)")
+            throw LaunchDaemonError.binaryNotFound
+        }
+
+        // Unload existing watcher if present
+        if FileManager.default.fileExists(atPath: watcherDaemonPath) {
+            unloadWatcherDaemon()
+        }
+
+        // Build watcher plist content
+        let plistContent = buildWatcherPlistContent()
+
+        // Write plist
+        try plistContent.write(toFile: watcherDaemonPath, atomically: true, encoding: .utf8)
+        Logger.shared.launchDaemon("Wrote watcher LaunchDaemon plist to \(watcherDaemonPath)")
+
+        // Set permissions
+        let fileManager = FileManager.default
+        try fileManager.setAttributes([
+            .posixPermissions: 0o644,
+            .ownerAccountName: "root",
+            .groupOwnerAccountName: "wheel"
+        ], ofItemAtPath: watcherDaemonPath)
+
+        // Load watcher daemon
+        loadWatcherDaemon()
+
+        Logger.shared.launchDaemon("Watcher LaunchDaemon created and loaded successfully")
+    }
+
+    private func buildWatcherPlistContent() -> String {
+        return """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>Label</key>
+            <string>\(preferenceDomain).watcher</string>
+            <key>ProgramArguments</key>
+            <array>
+                <string>\(binaryPath)</string>
+                <string>--domain</string>
+                <string>\(preferenceDomain)</string>
+                <string>--sync-check</string>
+            </array>
+            <key>StartInterval</key>
+            <integer>900</integer>
+            <key>EnvironmentVariables</key>
+            <dict>
+                <key>PATH</key>
+                <string>/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin</string>
+            </dict>
+            <key>StandardOutPath</key>
+            <string>/var/log/DDMmacOSUpdateReminder.log</string>
+            <key>StandardErrorPath</key>
+            <string>/var/log/DDMmacOSUpdateReminder.log</string>
+        </dict>
+        </plist>
+        """
+    }
+
+    private func loadWatcherDaemon() {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        process.arguments = ["bootstrap", "system", watcherDaemonPath]
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+
+            if process.terminationStatus == 0 {
+                Logger.shared.launchDaemon("Watcher LaunchDaemon loaded successfully")
+            } else {
+                Logger.shared.error("Failed to load watcher LaunchDaemon (exit: \(process.terminationStatus))")
+            }
+        } catch {
+            Logger.shared.error("Error loading watcher LaunchDaemon: \(error.localizedDescription)")
+        }
+    }
+
+    private func unloadWatcherDaemon() {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        process.arguments = ["bootout", "system", watcherDaemonPath]
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+            Logger.shared.launchDaemon("Unloaded existing watcher LaunchDaemon")
+        } catch {
+            // May fail if not loaded, that's OK
+        }
+    }
+
+    // MARK: - Schedule Sync Check
+
+    func needsScheduleSync() -> Bool {
+        // Check if main daemon plist exists
+        guard FileManager.default.fileExists(atPath: daemonPath) else {
+            Logger.shared.launchDaemon("Main daemon plist not found - sync not needed")
+            return false
+        }
+
+        // Read current schedule from daemon plist
+        guard let currentSchedule = getCurrentScheduleFromDaemon() else {
+            Logger.shared.launchDaemon("Could not read current schedule - sync needed")
+            return true
+        }
+
+        // Get configured schedule
+        let configuredSchedule = configuration.scheduleSettings.launchDaemonTimes.map {
+            (hour: $0.hour, minute: $0.minute)
+        }
+
+        // Compare schedules
+        if currentSchedule.count != configuredSchedule.count {
+            return true
+        }
+
+        for (current, configured) in zip(currentSchedule.sorted { ($0.hour, $0.minute) < ($1.hour, $1.minute) },
+                                          configuredSchedule.sorted { ($0.hour, $0.minute) < ($1.hour, $1.minute) }) {
+            if current.hour != configured.hour || current.minute != configured.minute {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    private func getCurrentScheduleFromDaemon() -> [(hour: Int, minute: Int)]? {
+        guard let plistData = FileManager.default.contents(atPath: daemonPath) else {
+            return nil
+        }
+
+        guard let plist = try? PropertyListSerialization.propertyList(from: plistData, format: nil) as? [String: Any] else {
+            return nil
+        }
+
+        guard let calendarIntervals = plist["StartCalendarInterval"] as? [[String: Any]] else {
+            return nil
+        }
+
+        var schedule: [(hour: Int, minute: Int)] = []
+        for interval in calendarIntervals {
+            if let hour = interval["Hour"] as? Int, let minute = interval["Minute"] as? Int {
+                schedule.append((hour: hour, minute: minute))
+            }
+        }
+
+        return schedule
     }
 }


### PR DESCRIPTION
## Summary

- Adds `--sync-check` argument for lightweight schedule comparison
- Creates watcher LaunchDaemon that runs every 15 minutes
- Automatically updates main LaunchDaemon when schedule changes detected
- Bumps version to 1.0.1

## Problem

When the Configuration Profile schedule settings are updated in Jamf Pro, the LaunchDaemon schedule doesn't automatically update because it was created at setup time. Previously required manual `--setup` run.

## Solution

The watcher daemon runs every 15 minutes with `--sync-check`:
1. Reads current schedule from main LaunchDaemon plist
2. Compares with Configuration Profile schedule
3. If different, regenerates main LaunchDaemon
4. Exits (minimal overhead)

## Files Changed

- `DDMNotifier/Sources/main.swift` - Add --sync-check argument and mode
- `DDMNotifier/Sources/LaunchDaemonManager/LaunchDaemonManager.swift` - Add watcher daemon and sync check methods

## Test plan

- [ ] Run `--setup` and verify both LaunchDaemons are created
- [ ] Verify watcher runs every 15 minutes
- [ ] Change schedule in config profile and verify watcher updates main daemon
- [ ] Verify `--sync-check` exits quickly with no dialog

Fixes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)